### PR TITLE
Revert applicationset image to argocd image

### DIFF
--- a/csdp/base_components/apps/argo-cd/_components/codefresh-base/kustomization.yaml
+++ b/csdp/base_components/apps/argo-cd/_components/codefresh-base/kustomization.yaml
@@ -6,8 +6,6 @@ resources:
 images:
   - name: quay.io/codefresh/argocd
     newTag: v2.5.5-cap-CR-verify-aud-claim
-  - name: quay.io/codefresh/applicationset
-    newTag: v0.4.2-CR-13254-remove-private-logs
 
 configMapGenerator:
   - behavior: merge

--- a/installer/helm/templates/argo-cd/install.yaml
+++ b/installer/helm/templates/argo-cd/install.yaml
@@ -10019,7 +10019,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/codefresh/applicationset:v0.4.2-CR-13254-remove-private-logs
+        image: quay.io/codefresh/argocd:v2.5.5-cap-CR-verify-aud-claim
         imagePullPolicy: Always
         name: argocd-applicationset-controller
         ports:


### PR DESCRIPTION
Reverting to use the same container image for `argocd` and `applicationset-controller`.

This change was introduced here: https://github.com/codefresh-io/csdp-official/pull/41

There is no explanation as to why this change was made in the PR which created this commit, and it is in direct conflict with how the upstream ArgoCD project manages `applicationset-controller`, which relies on the same container image as `argocd-server`.

The image that the reverted commit refers to comes from a repo / tag that is almost a year stale, and was marked as deprecated _prior_ to the generation of this image: https://github.com/codefresh-io/applicationset/releases/tag/v0.4.2

https://github.com/codefresh-io/applicationset/blame/master/README.md#L3-L5

For additional context, I am currently running the latest vanilla image from ArgoCD without issue:

quay.io/argoproj/argocd:v2.6.1

Related:
https://github.com/codefresh-io/argo-cd/pull/203