### PR TITLE
Fixed Helm chart for adding external cluster to namespace

### DIFF
--- a/add-cluster/helm/templates/secret.yaml
+++ b/add-cluster/helm/templates/secret.yaml
@@ -2,8 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "csdp-add-cluster.fullname" . }}-secret
+  namespace: {{ .Values.systemNamespace | default "kube-system" }}
   labels:
     {{- include "csdp-add-cluster.labels" . | nindent 4 }}
 type: Opaque
 data:
-  CSDP_TOKEN: {{ .Values.csdpToken | b64enc | quote }}
+  csdpToken: {{ .Values.csdpToken | b64enc | quote }}


### PR DESCRIPTION
The secret was created in the wrong namespace and with the wrong name

I fixed it by looking at the kustomize manifests (that worked just fine)