### PR TITLE
[CR-17365]: app-proxy bump

### DIFF
--- a/csdp/base_components/apps/app-proxy/_components/codefresh-base/kustomization.yaml
+++ b/csdp/base_components/apps/app-proxy/_components/codefresh-base/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Component
 images:
 - name: quay.io/codefresh/cap-app-proxy
   newName: quay.io/codefresh/cap-app-proxy
-  newTag: 1.2245.0
+  newTag: 1.2250.1
 
 resources:
 - app-proxy.deploy.yaml

--- a/csdp/base_components/apps/app-proxy/_components/codefresh-base/kustomization.yaml
+++ b/csdp/base_components/apps/app-proxy/_components/codefresh-base/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Component
 images:
 - name: quay.io/codefresh/cap-app-proxy
   newName: quay.io/codefresh/cap-app-proxy
-  newTag: 1.2250.1
+  newTag: 1.2251.0
 
 resources:
 - app-proxy.deploy.yaml


### PR DESCRIPTION
app proxy with new node version 16.20.0