### PR TITLE
CR-18417-app-proxy

### DIFF
--- a/csdp/base_components/apps/app-proxy/_components/codefresh-base/kustomization.yaml
+++ b/csdp/base_components/apps/app-proxy/_components/codefresh-base/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Component
 images:
 - name: quay.io/codefresh/cap-app-proxy
   newName: quay.io/codefresh/cap-app-proxy
-  newTag: 1.2260.1
+  newTag: 1.2264.1
 
 resources:
 - app-proxy.deploy.yaml


### PR DESCRIPTION
[app-proxy / runResourceAction query]: now requires runtime parameter to be passed