### PR TITLE
CR-19442-app-proxy

### DIFF
--- a/csdp/base_components/apps/app-proxy/_components/codefresh-base/kustomization.yaml
+++ b/csdp/base_components/apps/app-proxy/_components/codefresh-base/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Component
 images:
 - name: quay.io/codefresh/cap-app-proxy
   newName: quay.io/codefresh/cap-app-proxy
-  newTag: 1.2325.0
+  newTag: 1.2330.2
 
 resources:
 - app-proxy.deploy.yaml


### PR DESCRIPTION
app-proxy update with changes to applicationProxyQuery response: spec.source now optional