### PR TITLE
feat: enable ipv6 for internal-router

### DIFF
--- a/csdp/hybrid/basic/apps/internal-router/internal-router.cm.yaml
+++ b/csdp/hybrid/basic/apps/internal-router/internal-router.cm.yaml
@@ -6,39 +6,40 @@ data:
   default.conf.template: |
     server {
       listen 80 default_server;
+      listen [::]:80 default_server;
       root /usr/local/app;
       access_log /dev/stdout main;
       error_log /dev/stdout;
-    
-    
+
+
       location /app-proxy {
         # WebSocket support
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         chunked_transfer_encoding off;
-    
+
         proxy_pass http://cap-app-proxy:3017;
       }
-    
+
       location /workflows/ {
         # sse
         proxy_set_header Connection '';
         proxy_http_version 1.1;
         chunked_transfer_encoding off;
-    
+
         proxy_pass https://argo-server:2746/;
       }
-    
+
       location ~ /webhooks/([^/]+)/([^/]+) {
         resolver kube-dns.kube-system.svc.cluster.local valid=10s;
         proxy_pass http://$2-eventsource-svc.$1.svc.cluster.local;
       }
-    
+
       location /readyz {
         return 200 'ok';
       }
-    
+
       location /healthz {
         return 200 'ok';
       }


### PR DESCRIPTION
Enables IPv6 on internal-router. 

Previously, on dual stacked Kubernetes deployments `internal-router` would fail to start because nginx would only listen to IPv4 addresses and not IPv6. This change makes the server also listen on IPv6.

```
❯ kgp internal-router-6997b5f9d5-9dmpg -o wide
NAME                               READY   STATUS    RESTARTS   AGE   IP                 NODE                                                   NOMINATED NODE   READINESS GATES
internal-router-6997b5f9d5-9dmpg   1/1     Running   0          8d    2001:cafe:41::15   6e82d2e3aed918.vm.dev-k3s-cluster-sjc-01-cp.internal   <none>           <none>

❯ kgcm internal-router-config -o yaml| egrep '^[ ]+listen'
      listen 80 default_server;
      listen [::]:80 default_server;
```