### PR TITLE
CR-19830-argo-cd

### DIFF
--- a/csdp/base_components/apps/argo-cd/_components/codefresh-base/kustomization.yaml
+++ b/csdp/base_components/apps/argo-cd/_components/codefresh-base/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 
 images:
   - name: quay.io/codefresh/argocd
-    newTag: v2.7.0-cap-CR-18361-custom-instance-label
+    newTag: v2.7.0-cap-CR-19830-missing-labels
   - name: quay.io/codefresh/applicationset
     newTag: v0.4.2-CR-13254-remove-private-logs
 


### PR DESCRIPTION
update argo-cd with fix for cases when app doesn't have labels